### PR TITLE
Correct symlink documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ ns.stat(NETSTORAGE_PATH, callback(err, response, body))
 *[↑ back to method list](#methods)*
 - **Syntax**: 
 ```Javascript
-ns.symlink(NETSTORAGE_TARGET, NETSTORAGE_DESTINATION, callback(err, response, body))
+ns.symlink(NETSTORAGE_SOURCE, NETSTORAGE_TARGET, callback(err, response, body))
 ```
 - **Parameters**:
 
 	| Name        | Type        | Description                     |
 	| :---------- | :---------: | :------------------------------ |
-  | `NETSTORAGE_TARGET` | *string* | full path of the symlink to create |
-  | `NETSTORAGE_DESTINATION` | *string* | full path to file to symlink to |
+  | `NETSTORAGE_SOURCE` | *string* | full path to the original file |
+  | `NETSTORAGE_TARGET` | *string* | full path of the new symlinked file to create |
 
 ### upload
 *[↑ back to method list](#methods)*


### PR DESCRIPTION
The documentation for symlinks was confusing and misleading. The description of the arguments were the wrong way around.

I've updated the documentation to use phrases more inline with *nix parlance (`source` and `target`) and corrected the arguments.

Refs #6 