### PR TITLE
support uploading and testing on Windows

### DIFF
--- a/lib/netstorage.js
+++ b/lib/netstorage.js
@@ -154,7 +154,7 @@ class Netstorage {
   }
 
   upload(local_source, ns_destination, callback) {
-    if (local_source.endsWith('/') || !local_source.startsWith('/')) {
+    if (local_source.endsWith('/')) {
       return callback(new Error('[Netstorage Error] source must be a valid file'), null, null)
     }
     try {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Akamai Netstorage API for Node.js",
   "main": "./lib/netstorage.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --reporter spec --no-timeouts --ui bdd test/test-*"
+    "test": "mocha --reporter spec --no-timeouts --ui bdd test/test-*"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
Took a while to realise why the API wasn't working on Windows. Paths don't start with `/` on Windows, so it seems like a simple platform compatibility oversight.

Also, tests weren't working on Windows so the test script was updated.

Furthermore, I couldn't work out why the `list` method doesn't work for me, but that's unrelated to this PR.